### PR TITLE
Resto de las estadísticas por obtener

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -35,8 +35,7 @@ public class Main /*extends Application*/ {
 
         SistemaColas sim = new SistemaColas(distsServidores, distLlegadas);
 
-        for(int i =0; i<1000; i++) {
-            //sim = new SistemaColas(distsServidores, distLlegadas, sim.getEstadisticas());
+        for(int i =0; i<10000; i++) {
             sim.iniciarSimulacion(10, 6);
         }
 

--- a/src/main/java/Model/Estadisticas.java
+++ b/src/main/java/Model/Estadisticas.java
@@ -1,191 +1,222 @@
 package Model;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 
 public class Estadisticas {
     // SE REGISTRAN LOS TOTALES PARA CALCULAR LOS DATOS AL FINALIZAR
-    // TODO (a) the expected waiting time for a randomly selected job
+    // (a) the expected waiting time for a randomly selected job
     private Duration tiempoEsperandoEnColaTotal;
-    private LinkedList<Duration> duracionesEnCola;
 
-    // TODO (b) the expected response time;
+    // (b) the expected response time;
     private Duration tiempoDeRespuestaTotal;
-    private LinkedList<Duration> duracionesDeRespuesta;
 
-    // TODO (c) the expected length of a queue (excluding the jobs receiving service), when a new job arrives
-    private double tamañoDeColaTotalPorLlegada;
-    private LinkedList<Integer> longitudesEnCola;
+    // (c) the expected length of a queue (excluding the jobs receiving service), when a new job arrives
+    private int longitudDeColaPorLlegadaTotal;
 
-    // TODO (d) the expected maximum waiting time during a 10-hour day
-    private Duration tiempoDeEsperaMaximoTotal;
-    private LinkedList<Integer> longitudesEnColaMax;
+    // (d) the expected maximum waiting time during a 10-hour day
+    private Duration tiempoDeEsperaMaximoEnUnDia;   // reinicia con cada simulacion
+    private Duration tiempoDeEsperaMaximoTotal;     // promedio de todas las simulaciones
 
-    // TODO (e) the expected maximum length of a queue during a 10-hour day
-    private Duration tiempoDeEsperaMinimoTotal;
+    // (e) the expected maximum length of a queue during a 10-hour day
+    private int longitudDeColaMaximaEnUnDia;
+    private int longitudDeColaMaximaTotal;
 
-    // TODO (f) the probability that at least one server is available, when a job arrives
-    private double vecesUnServidorDisponibleTotales;
+    // (f) the probability that at least one server is available, when a job arrives
+    private int vecesUnServidorDisponibleTotales;
 
-    // TODO (g) the probability that at least two servers are available, when a job arrives
-    private double vecesDosServidoresDisponiblesTotales;
+    // (g) the probability that at least two servers are available, when a job arrives
+    private int vecesDosServidoresDisponiblesTotales;
 
     // (h) the expected number of jobs processed by each server
     private HashMap<String, Integer> trabajosProcesadosTotalesPorServidor = new HashMap<>();
 
-    // TODO (i) the expected time each server is idle during the day
-    private HashMap<String, Duration> tiempoOciosoTotalesPorServidor = new HashMap<>();
+    // (i) the expected time each server is idle during the day
+    private HashMap<String, Duration> tiemposOciosoTotalesPorServidor = new HashMap<>();
 
     // (j) the expected number of jobs still remaining in the system at 6:03 pm
     private double trabajosRestantesAlFinalizarTotales;
 
-    public Estadisticas() {
-        tiempoEsperandoEnColaTotal = Duration.ZERO;
-        tiempoDeRespuestaTotal = Duration.ZERO;
-        tamañoDeColaTotalPorLlegada = 0;
-        tiempoDeEsperaMaximoTotal = Duration.ZERO;
-        tiempoDeEsperaMinimoTotal = Duration.ZERO;
-        vecesUnServidorDisponibleTotales = 0;
-        vecesDosServidoresDisponiblesTotales = 0;
-        trabajosProcesadosTotalesPorServidor = new HashMap<>();
-        tiempoOciosoTotalesPorServidor = new HashMap<>();
-        trabajosRestantesAlFinalizarTotales = 0;
-        trabajosAbandonaronColaTotales = 0;
-        simulacionesEjecutadas = 0;
-        //llegadasTotales = 0;
-        trabajosFinalizadosTotales = 0;
-        longitudesEnCola = new LinkedList<Integer>();
-        duracionesEnCola = new LinkedList<Duration>();
-        duracionesDeRespuesta = new LinkedList<Duration>();
-    }
-
-    // TODO (k) the expected percentage of jobs that left the queue prematurely
+    // (k) the expected percentage of jobs that left the queue prematurely
     private double trabajosAbandonaronColaTotales;
 
     // para calcular (d), (e), (h), (i), (j)
     private int simulacionesEjecutadas;
 
-    // para calcular (c), (f), (g), (k)
-    //private int llegadasTotales;
+    // para calcular (a), (c), (f), (g), (k)
+    private int llegadasTotales;
 
     // para calcular (b)
     private int trabajosFinalizadosTotales;
 
+    public Estadisticas() {
+        tiempoEsperandoEnColaTotal = Duration.ZERO;
+        tiempoDeRespuestaTotal = Duration.ZERO;
+        longitudDeColaPorLlegadaTotal = 0;
+        tiempoDeEsperaMaximoEnUnDia = Duration.ZERO;
+        tiempoDeEsperaMaximoTotal = Duration.ZERO;
+        longitudDeColaMaximaEnUnDia = 0;
+        longitudDeColaMaximaTotal = 0;
+        vecesUnServidorDisponibleTotales = 0;
+        vecesDosServidoresDisponiblesTotales = 0;
+        trabajosProcesadosTotalesPorServidor = new HashMap<>();
+        tiemposOciosoTotalesPorServidor = new HashMap<>();
+        trabajosRestantesAlFinalizarTotales = 0;
+        trabajosAbandonaronColaTotales = 0;
+        simulacionesEjecutadas = 0;
+        llegadasTotales = 0;
+        trabajosFinalizadosTotales = 0;
+    }
 
     //Registra una llegada nueva
-    public void añadirLlegadaNueva(Integer longitudDeCola) {
-        longitudesEnCola.add(longitudDeCola);
+    public void añadirLlegadaNueva(int longitudDeCola, int servidoresDisponibles) {
+        // añadir la lllegada
+        llegadasTotales++;
+
+        // añadir la longitud a la longitud total
+        longitudDeColaPorLlegadaTotal += longitudDeCola;
+
+        // revisar si es la longitud máxima
+        if(longitudDeColaMaximaEnUnDia == 0 || longitudDeCola > longitudDeColaMaximaEnUnDia) {
+            longitudDeColaMaximaEnUnDia = longitudDeCola;
+        }
+
+        // registrar si hubo al menos 1 servidor disponible
+        if(servidoresDisponibles >= 1) {
+            vecesUnServidorDisponibleTotales++;
+        }
+
+        // registrar si hubieron al menos 2 servidores disponibles
+        if(servidoresDisponibles >= 2) {
+            vecesDosServidoresDisponiblesTotales++;
+        }
     }
 
-    //Registra un tiempo de espera en la cola. Nota: Si no pasó por cola el tiempo es 0.
+    //Registra un tiempo de espera en la cola. Nota: Si no pasó por cola el tiempo es 0
     public void añadirTiempoDeEsperaEnCola(Duration esperaEnCola) {
-        duracionesEnCola.add(esperaEnCola);
+        // sumar el tiempo esperado al tiempo esperado total
+        tiempoEsperandoEnColaTotal = tiempoEsperandoEnColaTotal.plus(esperaEnCola);
+
+        // revisar si es el tiempo de espera máximo
+        if(tiempoDeEsperaMaximoEnUnDia.equals(Duration.ZERO) || esperaEnCola.compareTo(tiempoDeEsperaMaximoEnUnDia)>0 ){
+            tiempoDeEsperaMaximoEnUnDia = Duration.from(esperaEnCola);
+        }
     }
 
-    // TODO enviar tiempo de respuesta en SistemaColas.java
+    public void añadirTrabajoAbandonoLaCola() {
+        trabajosAbandonaronColaTotales++;
+    }
+
     public void añadirTrabajoFinalizado(String nombreServidor, LocalTime tiempoDeEntrada, LocalTime tiempoDeSalida){
+        // añadir un trabajo finalizado
+        trabajosFinalizadosTotales++;
+
+        // registrar el servidor que lo completó
         if (trabajosProcesadosTotalesPorServidor.containsKey(nombreServidor)) {
+            // sumar al valor existente
             trabajosProcesadosTotalesPorServidor.put(nombreServidor, 1+trabajosProcesadosTotalesPorServidor.get(nombreServidor));
         } else {
+            // insertar por primera vez
             trabajosProcesadosTotalesPorServidor.put(nombreServidor,1);
         }
-        LocalTime diferenciaHora = diferenciaEntreLocalTimes(tiempoDeEntrada,tiempoDeSalida);
-        duracionesDeRespuesta.add(traducirLocalTimeADuration(diferenciaHora));
-        trabajosFinalizadosTotales++;
-        //tiempoDeRespuestaTotal.plus(tiempoRespuesta);
+
+        // calcular la diferencia de localTimes para encontrar el tiempo de respuesta, llamar abs() para garantizar que sea un tiempo positivo
+        Duration tiempoDeRespuesta = Duration.between(tiempoDeEntrada,tiempoDeSalida).abs();
+
+        // añadirlo al tiempo de respuesta total
+        tiempoDeRespuestaTotal = tiempoDeRespuestaTotal.plus(tiempoDeRespuesta);
     }
 
-    public void añadirTrabajosRestantesAlFinalizar(int trabajos){
-        trabajosRestantesAlFinalizarTotales += trabajos;
-    }
-
-    public void añadirSimulacion() {
+    // Registra los trabajos restantes y actualiza las variables de máximos
+    public void terminarSimulacion(int trabajosRestantes) {
+        // añadir una simulacion ejecutada
         simulacionesEjecutadas++;
+
+        // añadir los trabajos restantes sin procesar
+        trabajosRestantesAlFinalizarTotales += trabajosRestantes;
+
+        // procesar el tiempo de espera máximo en ese día
+        tiempoDeEsperaMaximoTotal = tiempoDeEsperaMaximoTotal.plus(tiempoDeEsperaMaximoEnUnDia);
+        tiempoDeEsperaMaximoEnUnDia = Duration.ZERO;                // reiniciar el tiempo máximo en un día para la siguiente simulación
+
+        // procesar la longitud de cola máxima en ese día
+        longitudDeColaMaximaTotal += longitudDeColaMaximaEnUnDia;   // reiniciar la longitd maxima en u dia para la siguiente simulacion
+        longitudDeColaMaximaEnUnDia = 0;
     }
 
-   /*public void añadirLlegada(){
+    // Añade tiempo ocioso a un servidor cuando se le asigna un trabajo al haber estado ocioso
+    public void añadirTiempoOciosoAServidor(String nombre, LocalTime tiempoInicio, LocalTime tiempoFin) {
+        if(tiemposOciosoTotalesPorServidor.containsKey(nombre)) {
+            // sumar al valor existente
+            tiemposOciosoTotalesPorServidor.put(nombre, tiemposOciosoTotalesPorServidor.get(nombre).plus(Duration.between(tiempoInicio,tiempoFin).abs()));
+        } else {
+            // insertar por primera vez
+            tiemposOciosoTotalesPorServidor.put(nombre, Duration.between(tiempoInicio,tiempoFin).abs());
+        }
+    }
 
-        llegadasTotales++;
-    }*/
+    // redondear doubles a dos decimales
+    public double redondear(double value) {
+        BigDecimal bd = new BigDecimal(value);
+        bd = bd.setScale(2, RoundingMode.HALF_UP);
+        return bd.doubleValue();
+    }
 
     public String procesarDatos() {
         String resultado = "Simulaciones ejecutadas: " + simulacionesEjecutadas + "\n";
 
-        //Cálculo del tiempo esperado de espera de un trabajo
-        Duration waitingTime = Duration.ofNanos(0);
-        for (Duration duration: duracionesEnCola) waitingTime = waitingTime.plus(duration);
-        waitingTime = waitingTime.dividedBy(duracionesEnCola.size());
-        resultado += "(a) Tiempo esperado de espera de un trabajo cualquiera (Wq): " + waitingTime.getSeconds()/60 + " min " + waitingTime.getSeconds() % 60 + " s\n";
+        // Cálculo del tiempo esperado de espera de un trabajo
+        Duration tiempoEsperandoEnColaEsperado = tiempoEsperandoEnColaTotal.dividedBy(llegadasTotales);
+        resultado += "(a) Tiempo esperado de espera de un trabajo cualquiera (Wq): " + tiempoEsperandoEnColaEsperado.getSeconds()/60 + " min " + tiempoEsperandoEnColaEsperado.getSeconds() % 60 + " s\n";
 
-        //Cálculo del tiempo esperado de respuesta
-        Duration responseTime = Duration.ofNanos(0);
-        for (Duration duration: duracionesDeRespuesta)
-            responseTime = responseTime.plus(duration);
-        responseTime = responseTime.dividedBy(duracionesDeRespuesta.size());
-        resultado += "(b) Tiempo esperado de respuesta (W): " + responseTime.getSeconds()/60 + " min " + responseTime.getSeconds() % 60 + " s\n";
+        // Cálculo del tiempo esperado de respuesta
+        Duration tiempoDeRespuestaEsperado = tiempoDeRespuestaTotal.dividedBy(trabajosFinalizadosTotales);
+        resultado += "(b) Tiempo esperado de respuesta (W): " + tiempoDeRespuestaEsperado.getSeconds()/60 + " min " + tiempoDeRespuestaEsperado.getSeconds() % 60 + " s\n";
 
-        double longitud = 0;
-        for (Integer i : longitudesEnCola) longitud += i;
-        resultado += "(c) Longitud esperada de Cola (Lq):" + longitud / longitudesEnCola.size() + " trabajos\n";
+        // Cálculo de la longitud esperada de la cola al darse una llegada
+        double longitudDeColaPorLlegadaEsperada = (double)longitudDeColaPorLlegadaTotal/llegadasTotales;
+        resultado += "(c) Longitud esperada de la cola cuando se da una llegada (Lq): " + redondear(longitudDeColaPorLlegadaEsperada) + " trabajos\n";
 
-        double max = 0;
+        // Tiempo máximo de espera esperado
+        Duration tiempoDeEsperaMaximoEsperado = tiempoDeEsperaMaximoTotal.dividedBy(simulacionesEjecutadas);
+        resultado += "(d) Tiempo de espera máximo esperado: "+ tiempoDeEsperaMaximoEsperado.getSeconds()/60 + " min " + tiempoDeEsperaMaximoEsperado.getSeconds() % 60 + " s\n";
 
-        for (Integer i : longitudesEnCola) {
-            if (i > max) {
-                max = i;
-            }
-        }
-        resultado += "(e) Longitud máxima esperada en la cola es: " + max +" trabajos \n";
+        // Longitud máxima esperada en la cola
+        double longitudDeColaMaximaEsperada = (double) longitudDeColaMaximaTotal/simulacionesEjecutadas;
+        resultado += "(e) Longitud máxima esperada en la cola: " + redondear(longitudDeColaMaximaEsperada) +" trabajos \n";
 
-        resultado+="(h) Trabajos procesados esperados: "+((double)trabajosFinalizadosTotales/simulacionesEjecutadas);
+        // Probabilidad de que hubiera al menos 1 servidor disponible al entrar un trabajo
+        double probabilidadUnServidorDisponible = (double) vecesUnServidorDisponibleTotales/llegadasTotales * 100;
+        resultado += "(f) Probabilidad de que haya al menos 1 servidor disponible al entrar un trabajo "+redondear(probabilidadUnServidorDisponible)+"%\n";
+
+        // Probabilidad de que hubieran al menos 2 servidores disponibles al entrar un trabajo
+        double probabilidadDosServidoresDisponibles = (double) vecesDosServidoresDisponiblesTotales/llegadasTotales * 100;
+        resultado += "(g) Probabilidad de que haya al menos 2 servidores disponibles al entrar un trabajo "+redondear(probabilidadDosServidoresDisponibles)+"%\n";
+
+        // Trabajos procesados totales y por cada servidor
+        resultado+="(h) Trabajos procesados esperados: "+(redondear((double)trabajosFinalizadosTotales/simulacionesEjecutadas));
         for(String nombre : trabajosProcesadosTotalesPorServidor.keySet()) {
-            resultado+="\n  procesados por "+nombre+": "+((double)trabajosProcesadosTotalesPorServidor.get(nombre)/simulacionesEjecutadas);
+            resultado+="\n       -"+nombre+": "+(redondear((double)trabajosProcesadosTotalesPorServidor.get(nombre)/simulacionesEjecutadas))+" trabajos";
         }
+
+        // Tiempo esperado ocioso de cada servidor
+        resultado+="\n(i) Tiempo ocioso esperado de cada servidor:";
+        Duration tiempoOciosoEsperadoPorServidor;
+        for(String nombre : tiemposOciosoTotalesPorServidor.keySet()) {
+            tiempoOciosoEsperadoPorServidor = tiemposOciosoTotalesPorServidor.get(nombre).dividedBy(simulacionesEjecutadas);
+            resultado+="\n       -"+nombre+": "+tiempoOciosoEsperadoPorServidor.getSeconds()/60+" min " + tiempoOciosoEsperadoPorServidor.getSeconds()%60 + " s";
+        }
+
+        // Trabajos no procesados a las 6:03pm
         resultado+="\n(j) Trabajos restantes esperados a las 6:03pm: "+((double)trabajosRestantesAlFinalizarTotales/simulacionesEjecutadas)+"\n";
 
+        // Trabajos esperados que abandonan la cola
+        double trabajosAbandonaronColaEsperados = (double) trabajosAbandonaronColaTotales/llegadasTotales * 100;
+        resultado += "(k) Porcentaje esperado de trabajos que abandonaron la cola prematuramente "+redondear(trabajosAbandonaronColaEsperados)+"%\n";
 
         return resultado;
-    }
-
-    private LocalTime diferenciaEntreLocalTimes(LocalTime a, LocalTime b){
-        //LocalTime a = LocalTime.of(1984, 12, 16, 7, 45, 55);
-        //LocalTime b = LocalTime.of(2014, 9, 10, 6, 40, 45);
-
-
-        LocalTime tempDateTime = LocalTime.from( a );
-
-        //tempDateTime.minusNanos((long)b.getNano());
-        long nanos = a.until( b, ChronoUnit.NANOS);
-        long seconds = nanos / 1000000000;
-        long minutes = seconds / 60;
-        long hours = minutes / 60;
-        nanos = nanos % 1000000000;
-        seconds = seconds % 60;
-        LocalTime result = LocalTime.of((int)hours,(int)minutes,(int)seconds,(int)nanos);
-        /*tempDateTime = tempDateTime.plusNanos( nanos );*/
-/*
-
-        tempDateTime = tempDateTime.plusSeconds( seconds );
-
-
-        tempDateTime = tempDateTime.plusMinutes( minutes );
-
-        long hours = tempDateTime.until( b, ChronoUnit.HOURS);
-        tempDateTime = tempDateTime.plusHours( hours );*/
-        return  result;
-    }
-
-    private Duration traducirLocalTimeADuration(LocalTime time){
-        long nanos = 0;
-        long seconds = 0;
-        nanos += time.getNano();
-        seconds += time.getSecond();
-        seconds += time.getMinute() * 60;
-        seconds += time.getHour() * 60 * 60;
-        return Duration.ofSeconds(seconds,nanos);
     }
 }

--- a/src/main/java/Model/Servidor.java
+++ b/src/main/java/Model/Servidor.java
@@ -29,17 +29,18 @@ public class Servidor implements Comparable{
         tiempoSalida = tiempoActual.plus(tiempoServicio); // calcular su tiempo de salida
     }
 
+    // para poder registrar los tiempos de respuesta, recibe el tiempo en que llegó el trabajo
     public void asignarTrabajo(LocalTime tiempoActual, LocalTime tiempoDeEntradaAlSistema) {
         ocupado = true; // ahora esta ocupado
-        this.tiempoDeEntradaAlSistema = tiempoDeEntradaAlSistema;
+        this.tiempoDeEntradaAlSistema = LocalTime.from(tiempoDeEntradaAlSistema);
         // Duration requiere un int, se transforma a nanosegundos para obtener la mejor precisión
         tiempoServicio = Duration.ofNanos(Math.round(distribucionTiempoServicio.calcular()*60000000000L));
         tiempoSalida = tiempoActual.plus(tiempoServicio); // calcular su tiempo de salida
     }
 
-    public void terminarTrabajo() {
+    public void terminarTrabajo(LocalTime tiempoActual) {
         ocupado = false; // está ocioso
-        tiempoSalida = LocalTime.MAX;  // conviene asignarlo al tiempo máximo para hacer comparaciones con otros servidores
+        tiempoSalida = LocalTime.from(tiempoActual);  // se asigna al tiempo actual para poder registrar cuanto tiempo el servidor he estado ocioso
     }
 
     public LocalTime getTiempoSalida() {


### PR DESCRIPTION
Arreglos menores a obtención de estadísticas ya resueltas
Arreglo a la eliminación de trabajos que exceden su tiempo en cola, anteriormente se hacía ANTES de actualizar el tiempo actual, por lo que podían quedar trabajos que deberían haber sido eliminados
Redondeo de estadísticas al imprimir